### PR TITLE
Add basic support for PointValues attached to the points of a PointCloud, development towards #1

### DIFF
--- a/CockroachGH/Cleaning/CloudBoxCrop.cs
+++ b/CockroachGH/Cleaning/CloudBoxCrop.cs
@@ -11,22 +11,20 @@ namespace CockroachGH {
 
         public CloudBoxCrop()
   : base("CloudBoxCrop", "CloudBoxCrop",
-      "CloudBoxCrop",
-      "Cockroach", "Crop") {
+         "Crop a PointCloud with one or many boxes, getting either the inside or the outside of the boxes as a new PointCloud.",
+         "Cockroach", "Crop") {
         }
         public override GH_Exposure Exposure => GH_Exposure.quarternary;
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager) {
-            pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "PointCloud", GH_ParamAccess.item);
-            pManager.AddBrepParameter("Boxes", "B", "Boxes",GH_ParamAccess.list);
-            pManager.AddBooleanParameter("Inverse","I","Get Outside part of box", GH_ParamAccess.item, false);
+            pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "The PointCloud to crop.", GH_ParamAccess.item);
+            pManager.AddBrepParameter("Boxes", "B", "The boxes to crop PointCloud with.",GH_ParamAccess.list);
+            pManager.AddBooleanParameter("Inverse","I","If set to True, will get the outside part of the box.", GH_ParamAccess.item, false);
             pManager[2].Optional = true;
           }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager) {
-
             pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "PointCloud", GH_ParamAccess.item);
-
         }
 
         protected override void SolveInstance(IGH_DataAccess DA) {
@@ -43,21 +41,16 @@ namespace CockroachGH {
 
             PointCloud c = CropBox(cgh.Value, boxes, inverse, true);
 
-
             DA.SetData(0, new GH_Cloud(c));
-
-
         }
-
 
         public PointCloud CropBox(PointCloud cloud, List<Brep> boxes, bool inverse = false, bool parallel = false) {
 
 
             bool[] flags = new bool[cloud.Count];
 
-            foreach (var brep in boxes) {
-
-
+            foreach (var brep in boxes)
+            {
                 brep.Surfaces[0].TryGetPlane(out Plane plane);
                 Box box = new Box(plane, brep);
 
@@ -74,23 +67,22 @@ namespace CockroachGH {
                 Point3d Max = b.PointAt(1, 1, 1);
                 //Rhino.RhinoDoc.ActiveDoc.Objects.AddBox(b);
 
-                System.Threading.Tasks.Parallel.For(0, cloudCopy.Count, i => {
-
+                System.Threading.Tasks.Parallel.For(0, cloudCopy.Count, i =>
+                {
                     if (flags[i]) return;
                     var p = cloudCopy[i].Location;
                     bool flag = (Min.X < p.X) && (Max.X > p.X) && (Min.Y < p.Y) && (Max.Y > p.Y) &&  (Min.Z < p.Z) && (Max.Z > p.Z);
                     if (flag) flags[i] = true;
-
                 });
             }
 
-
-
             int count = 0;
             List<int> idList = new List<int>();
-            for (int i = 0; i < cloud.Count; i++) {
+            for (int i = 0; i < cloud.Count; i++)
+            {
                 bool f = inverse ? !flags[i] : flags[i];
-                if (f) {
+                if (f)
+                {
                     idList.Add(i);
                     count++;
                 }
@@ -100,22 +92,28 @@ namespace CockroachGH {
             Point3d[] points = new Point3d[count];
             Vector3d[] normals = new Vector3d[count];
             Color[] colors = new Color[count];
+            double[] pvalues = new double[count];
 
-            System.Threading.Tasks.Parallel.For(0, idArray.Length, i => {
-
-
+            System.Threading.Tasks.Parallel.For(0, idArray.Length, i =>
+            {
                 int id = idArray[i];
                 var p = cloud[(int)id];
                 points[i] = p.Location;
                 normals[i] = p.Normal;
                 colors[i] = p.Color;
-
+                pvalues[i] = p.PointValue;
             });
 
             PointCloud croppedCloud = new PointCloud();
-            croppedCloud.AddRange(points, normals, colors);
-
-
+            if (cloud.ContainsPointValues)
+            {
+                croppedCloud.AddRange(points, normals, colors, pvalues);
+            }
+            else
+            {
+                croppedCloud.AddRange(points, normals, colors);
+            }
+            
 
            
             //for (int i = 0; i < cloud.Count; i++) {
@@ -129,7 +127,6 @@ namespace CockroachGH {
             //    }
             //}
             return croppedCloud;
-
         }
 
         //public void CropCloud(PointCloud cloud, ref bool[] flags, Box box, bool inverse = false, bool parallel = false) {

--- a/CockroachGH/Cleaning/CloudBoxCrop.cs
+++ b/CockroachGH/Cleaning/CloudBoxCrop.cs
@@ -11,20 +11,20 @@ namespace CockroachGH {
 
         public CloudBoxCrop()
   : base("CloudBoxCrop", "CloudBoxCrop",
-         "Crop a PointCloud with one or many boxes, getting either the inside or the outside of the boxes as a new PointCloud.",
+         "Crop a PointCloud with one or multiple Boxes, returning either the inside or the outside of the Box(es) as a new PointCloud.",
          "Cockroach", "Crop") {
         }
         public override GH_Exposure Exposure => GH_Exposure.quarternary;
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager) {
             pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "The PointCloud to crop.", GH_ParamAccess.item);
-            pManager.AddBrepParameter("Boxes", "B", "The boxes to crop PointCloud with.",GH_ParamAccess.list);
-            pManager.AddBooleanParameter("Inverse","I","If set to True, will get the outside part of the box.", GH_ParamAccess.item, false);
+            pManager.AddBrepParameter("Boxes", "B", "The Box(es) to crop PointCloud with.",GH_ParamAccess.list);
+            pManager.AddBooleanParameter("Inverse","I","If set to True, will get the outside part of the Box.", GH_ParamAccess.item, false);
             pManager[2].Optional = true;
           }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager) {
-            pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "PointCloud", GH_ParamAccess.item);
+            pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "The cropped PointCloud.", GH_ParamAccess.item);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA) {

--- a/CockroachGH/PointCloudParam/CloudAddPointValues.cs
+++ b/CockroachGH/PointCloudParam/CloudAddPointValues.cs
@@ -1,0 +1,107 @@
+﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+using System;
+using System.Collections.Generic;
+
+namespace CockroachGH {
+    public class CloudAddPointValues : GH_Component {
+
+        public CloudAddPointValues()
+  : base("CloudAddPointValues", "AddPointValues",
+         "Add extra values (i.e. for intensity) to the points of an existing PointCloud.",
+         "Cockroach", "Cloud") {
+        }
+        public override GH_Exposure Exposure => GH_Exposure.quarternary;
+
+        protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager) {
+            pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "The PointCloud to add extra values to.", GH_ParamAccess.item);
+            pManager.AddNumberParameter("Values", "V", "The extra values to add to the points of the PointCloud (i.e. intensity). If the length of supplied values is less than the number of points in the cloud, it will be filled with zeros. If it exceeds the number of points, it will be truncated.", GH_ParamAccess.list);
+        }
+
+        protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager) {
+            pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "The PointCloud with extra values added to its points.", GH_ParamAccess.item);
+        }
+
+        protected override void SolveInstance(IGH_DataAccess DA) {
+
+            try
+            {
+                // retrieve PointCloud from input data
+                var cgh = new GH_Cloud();
+                DA.GetData(0, ref cgh);
+
+                var v = new List<double>();
+                DA.GetDataList(1, v);
+
+                // create new PointCloud
+                PointCloud cloud = new PointCloud();
+
+                // get points, initialize numbers and colors
+                var p = cgh.Value.GetPoints();
+                Vector3d[] n;
+                System.Drawing.Color[] c;
+
+                // check and sanitize normals if necessary
+                n = cgh.Value.GetNormals();
+                if (n.Length == 0)
+                {
+                    n = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Repeat(Vector3d.Unset, p.Length));
+                }
+
+                // check and sanitize colors if necessary
+                c = cgh.Value.GetColors();
+                if (c.Length == 0)
+                {
+                    c = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Repeat(System.Drawing.Color.Black, p.Length));
+                }
+
+                // check length of list of input values
+                if (p.Length == v.Count)
+                {
+                    // add everying to new cloud
+                    cloud.AddRange(p, n, c, v);
+                }
+                else
+                {
+                    // truncate / fill values list
+                    double[] arrv = new double[p.Length];
+                    System.Threading.Tasks.Parallel.For(0, arrv.Length, i =>
+                    {
+                        if (i < v.Count) arrv[i] = v[i];
+                    });
+                    // add everying to new cloud
+                    cloud.AddRange(p, n, c, arrv);
+                }
+
+                // clear normals if input cloud did not have them 
+                if (!cgh.Value.ContainsNormals)
+                {
+                    cloud.ClearNormals();
+                }
+                // clear colors if input cloud did not have them
+                if (!cgh.Value.ContainsColors)
+                {
+                    cloud.ClearNormals();
+                }
+
+                // prepare data for output
+                DA.SetData(0, new GH_Cloud(cloud));
+            }
+            catch (Exception e)
+            {
+                Rhino.RhinoApp.WriteLine(e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Gets the unique ID for this component. Do not change this ID after release.
+        /// </summary>
+        public override Guid ComponentGuid {
+            get { return new Guid("88037ed0-5dda-483b-be15-e05ef45dcaf0"); }
+        }
+
+        protected override System.Drawing.Bitmap Icon => Properties.Resources.Cloud;
+    }
+}

--- a/CockroachGH/PointCloudParam/CloudPointValues.cs
+++ b/CockroachGH/PointCloudParam/CloudPointValues.cs
@@ -1,0 +1,52 @@
+﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+using System;
+using System.Collections.Generic;
+
+namespace CockroachGH {
+    public class CloudPointValues : GH_Component {
+
+        public CloudPointValues()
+  : base("CloudPointValues", "PointValues",
+         "Retrieve the extra PointValues attached to the points of a PointCloud.",
+         "Cockroach", "Cloud") {
+        }
+        public override GH_Exposure Exposure => GH_Exposure.quarternary;
+
+        protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager) {
+            pManager.AddParameter(new Param_Cloud(), "PointCloud", "C", "The PointCloud to retrieve the extra PointValues from.", GH_ParamAccess.item);
+        }
+
+        protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager) {
+            pManager.AddNumberParameter("Values", "V", "The extra PointValues attached to the points of the PointCloud (i.e. for intensity).", GH_ParamAccess.list);
+        }
+
+        protected override void SolveInstance(IGH_DataAccess DA) {
+
+            // Input
+            try {
+                var cgh = new GH_Cloud();
+                DA.GetData(0, ref cgh);
+
+                DA.SetDataList(0, cgh.Value.GetPointValues());
+            }
+            catch(Exception e)
+            {
+                Rhino.RhinoApp.WriteLine(e.ToString());
+            }
+
+        }
+
+
+        /// <summary>
+        /// Gets the unique ID for this component. Do not change this ID after release.
+        /// </summary>
+        public override Guid ComponentGuid {
+            get { return new Guid("686a4bfe-5c53-401d-be82-ecc0dd99e54a"); }
+        }
+
+        protected override System.Drawing.Bitmap Icon => Properties.Resources.Cloud;
+    }
+}

--- a/CockroachGH/PointCloudParam/GH_Cloud.cs
+++ b/CockroachGH/PointCloudParam/GH_Cloud.cs
@@ -37,16 +37,9 @@ namespace CockroachGH {
             }
         }
 
-
-
- 
-
-
-
         public override bool IsGeometryLoaded {
             get { return base.m_value != null; }
         }
-
 
         public override bool IsValid {
             get {
@@ -97,7 +90,6 @@ namespace CockroachGH {
             this.ReferenceGuid = Guid.Empty;
             this.ScanPos = Plane.WorldXY;
         }
-
         public GH_Cloud(GH_Cloud other) {
             this.ScanPos = Plane.WorldXY;
             this.ReferenceGuid = Guid.Empty;
@@ -326,8 +318,7 @@ namespace CockroachGH {
         }
 
         public override string ToString() {
-            return string.Format("PointCloud {0} HasNormals {1} HasColors {2}", this.m_value.Count, this.m_value.ContainsNormals, this.m_value.ContainsColors).ToString();
-
+            return string.Format("PointCloud {0} HasNormals {1} HasColors {2} HasPointValues {3}", this.m_value.Count, this.m_value.ContainsNormals, this.m_value.ContainsColors, this.m_value.ContainsPointValues).ToString();
         }
 
         public override IGH_GeometricGoo Transform(Transform xform) {


### PR DESCRIPTION
Added two new components for adding and retrieving the PointValues attached to the points of a point cloud.
Unforunately, there are a lot of bugs in RhinoCommon at the moment, resulting in a complicated implementation (for now). Once the setter works again, this can be simplified a lot.

For further info on the current bugs see:
https://discourse.mcneel.com/t/clearing-color-from-point-clouds-using-rhinocommon-clearcolors-in-c/125985/5?u=efestwin